### PR TITLE
moved the log messages to debugf

### DIFF
--- a/amqp/rabbitmq_test.go
+++ b/amqp/rabbitmq_test.go
@@ -14,7 +14,6 @@ type RabbitMQSuite struct{ psq PubSubQ }
 var _ = check.Suite(&RabbitMQSuite{})
 
 func (s *RabbitMQSuite) SetUpSuite(c *check.C) {
-	// init BeeLogger
 	p, err := NewRabbitMQ("amqp://guest:guest@localhost:5672/", "testq")
 	s.psq = p
 	c.Assert(err, check.IsNil)


### PR DESCRIPTION
- amqp log messages are minimal with just reporting `success`  only on debug mode prefixed with 
`[amqp`
- riak log messages are reported prefixed with `[riak]`