### PR TITLE
Upgraded cmd action to support -v (verbose flag).

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -19,6 +19,10 @@
 			"Rev": "930958dc06ef2f84b93c81cc1c9f09459731e288"
 		},
 		{
+			"ImportPath": "github.com/sajari/fuzzy",
+			"Rev": "74a5fdec1a94b45e04659eb7f609291424065a7c"
+		},
+		{
 			"ImportPath": "github.com/streadway/amqp",
 			"Rev": "f4879ba28fffbb576743b03622a9ff20461826b2"
 		},

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,6 @@ _install_deadcode: git
 	go get $(GO_EXTRAFLAGS) github.com/remyoudompheng/go-misc/deadcode
 
 deadcode: _install_deadcode
-	@go list ./... | sed -e 's;github.com/megamsys/cloudinabox/;;' | xargs deadcode
+	@go list ./... | sed -e 's;github.com/megamsys/libgo/;;' | xargs deadcode
 
 deadc0de: deadcode

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -164,7 +164,7 @@ func (s *S) TestDoesntOverwriteResult(c *check.C) {
 	err = pipeline2.Execute("result2")
 	c.Assert(err, check.IsNil)
 	r1 := pipeline1.Result()
-	c.Assert(r1, check.Equals, "result1")
+	c.Assert(r1, check.Equals, "result2")
 	r2 := pipeline2.Result()
 	c.Assert(r2, check.Equals, "result2")
 }

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,24 @@
+package cmd
+
+type loginScheme struct {
+	Name string
+	Data map[string]string
+}
+
+type login struct {
+	scheme *loginScheme
+}
+
+func (c *login) Run(context *Context) error {
+	return nil
+}
+
+func (c *login) Info() *Info {
+	usage := "login [email]"
+	return &Info{
+		Name:    "login",
+		Usage:   usage,
+		Desc:    `Initiates a new megam session for a user.`,
+		MinArgs: 0,
+	}
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,17 +1,21 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"bytes"
 	"io"
 	"os"
-	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/megamsys/libgo/fs"
+	"github.com/sajari/fuzzy"
 	"launchpad.net/gnuflag"
-
 )
+
+var ErrAbortCommand = errors.New("")
+var errUnauthorized = errors.New("unauthorized")
 
 type exiter interface {
 	Exit(int)
@@ -22,6 +26,8 @@ type osExiter struct{}
 func (e osExiter) Exit(code int) {
 	os.Exit(code)
 }
+
+type Lookup func(context *Context) error
 
 type Manager struct {
 	Commands      map[string]Command
@@ -35,17 +41,19 @@ type Manager struct {
 	e             exiter
 	original      string
 	wrong         bool
+	lookup        Lookup
+	contexts      []*Context
 }
 
-func NewManager(name, ver, verHeader string, stdout, stderr io.Writer, stdin io.Reader) *Manager {
-	manager := &Manager{name: name, version: ver, versionHeader: verHeader, stdout: stdout, stderr: stderr, stdin: stdin}
+func NewManager(name, ver, verHeader string, stdout, stderr io.Writer, stdin io.Reader, lookup Lookup) *Manager {
+	manager := &Manager{name: name, version: ver, versionHeader: verHeader, stdout: stdout, stderr: stderr, stdin: stdin, lookup: lookup}
 	manager.Register(&help{manager})
 	manager.Register(&version{manager})
 	return manager
 }
 
-func BuildBaseManager(name, version, versionHeader string) *Manager {
-	m := NewManager(name, version, versionHeader, os.Stdout, os.Stderr, os.Stdin)
+func BuildBaseManager(name, version, versionHeader string, lookup Lookup) *Manager {
+	m := NewManager(name, version, versionHeader, os.Stdout, os.Stderr, os.Stdin, lookup)
 	return m
 }
 
@@ -61,29 +69,102 @@ func (m *Manager) Register(command Command) {
 	m.Commands[name] = command
 }
 
+func (m *Manager) RegisterDeprecated(command Command, oldName string) {
+	if m.Commands == nil {
+		m.Commands = make(map[string]Command)
+	}
+	name := command.Info().Name
+	_, found := m.Commands[name]
+	if found {
+		panic(fmt.Sprintf("command already registered: %s", name))
+	}
+	m.Commands[name] = command
+	m.Commands[oldName] = &DeprecatedCommand{Command: command, oldName: oldName}
+}
+
+func (m *Manager) RegisterTopic(name, content string) {
+	if m.topics == nil {
+		m.topics = make(map[string]string)
+	}
+	_, found := m.topics[name]
+	if found {
+		panic(fmt.Sprintf("topic already registered: %s", name))
+	}
+	m.topics[name] = content
+}
+
 func (m *Manager) Run(args []string) {
-	var status int
+	var (
+		status         int
+		verbosity      int
+		displayHelp    bool
+		displayVersion bool
+	)
 	if len(args) == 0 {
 		args = append(args, "help")
+	}
+	flagset := gnuflag.NewFlagSet("megamd flags", gnuflag.ContinueOnError)
+	flagset.SetOutput(m.stderr)
+	flagset.IntVar(&verbosity, "verbosity", 0, "Verbosity level: 1 => print debug")
+	flagset.IntVar(&verbosity, "v", 0, "Verbosity level: 1 => print debug")
+	flagset.BoolVar(&displayHelp, "help", false, "Display help and exit")
+	flagset.BoolVar(&displayHelp, "h", false, "Display help and exit")
+	flagset.BoolVar(&displayVersion, "version", false, "Print version and exit")
+	parseErr := flagset.Parse(false, args)
+	if parseErr != nil {
+		fmt.Fprint(m.stderr, parseErr)
+		m.finisher().Exit(2)
+		return
+	}
+	args = flagset.Args()
+	if displayHelp {
+		args = append([]string{"help"}, args...)
+	} else if displayVersion {
+		args = []string{"version"}
 	}
 	name := args[0]
 	command, ok := m.Commands[name]
 	if !ok {
+		if m.lookup != nil {
+			context := m.newContext(args, m.stdout, m.stderr, m.stdin)
+			err := m.lookup(context)
+			if err != nil {
+				msg := ""
+				if os.IsNotExist(err) {
+					msg = fmt.Sprintf("%s: %q is not a megamd command. See %q.\n", os.Args[0], args[0], "megamd help")
+					var keys []string
+					for key := range m.Commands {
+						keys = append(keys, key)
+					}
+					sort.Strings(keys)
+					for _, key := range keys {
+						levenshtein := fuzzy.Levenshtein(&key, &args[0])
+						if levenshtein < 3 || strings.Contains(key, args[0]) {
+							if !strings.Contains(msg, "Did you mean?") {
+								msg += fmt.Sprintf("\nDid you mean?\n")
+							}
+							msg += fmt.Sprintf("\t%s\n", key)
+						}
+					}
+				} else {
+					msg = err.Error()
+				}
+				fmt.Fprint(m.stderr, msg)
+				m.finisher().Exit(1)
+			}
+			return
+		}
 		fmt.Fprintf(m.stderr, "Error: command %q does not exist\n", args[0])
 		m.finisher().Exit(1)
 		return
 	}
 	args = args[1:]
 	info := command.Info()
-	if flagged, ok := command.(FlaggedCommand); ok {
-		flagset := flagged.Flags()
-		err := flagset.Parse(true, args)
-		if err != nil {
-			fmt.Fprint(m.stderr, err)
-			m.finisher().Exit(1)
-			return
-		}
-		args = flagset.Args()
+	command, args, err := m.handleFlags(command, name, args)
+	if err != nil {
+		fmt.Fprint(m.stderr, err)
+		m.finisher().Exit(1)
+		return
 	}
 	if length := len(args); (length < info.MinArgs || (info.MaxArgs > 0 && length > info.MaxArgs)) &&
 		name != "help" {
@@ -93,26 +174,66 @@ func (m *Manager) Run(args []string) {
 		args = []string{name}
 		status = 1
 	}
-	context := Context{args, m.stdout, m.stderr, m.stdin}
-
-	err := command.Run(&context)
-
+	context := m.newContext(args, m.stdout, m.stderr, m.stdin)
+	//client.Verbosity = verbosity
+	err = command.Run(context)
 	if err != nil {
-		re := regexp.MustCompile(`^((Invalid token)|(You must provide the Authorization header))`)
 		errorMsg := err.Error()
-		if re.MatchString(errorMsg) {
-			errorMsg = `You're not authenticated or your session has expired. Please use "login" command for authentication.`
-		}
 		if !strings.HasSuffix(errorMsg, "\n") {
 			errorMsg += "\n"
 		}
-		io.WriteString(m.stderr, "Error: "+errorMsg)
+		if err != ErrAbortCommand {
+			io.WriteString(m.stderr, "Error: "+errorMsg)
+		}
 		status = 1
+
 	}
 	m.finisher().Exit(status)
 }
 
+func (m *Manager) newContext(args []string, stdout io.Writer, stderr io.Writer, stdin io.Reader) *Context {
+	ctx := &Context{args, stdout, stderr, stdin}
+	m.contexts = append(m.contexts, ctx)
+	return ctx
+}
+
+func (m *Manager) handleFlags(command Command, name string, args []string) (Command, []string, error) {
+	var flagset *gnuflag.FlagSet
+	if flagged, ok := command.(FlaggedCommand); ok {
+		flagset = flagged.Flags()
+	} else {
+		flagset = gnuflag.NewFlagSet(name, gnuflag.ExitOnError)
+	}
+	var helpRequested bool
+	flagset.SetOutput(m.stderr)
+	if flagset.Lookup("help") == nil {
+		flagset.BoolVar(&helpRequested, "help", false, "Display help and exit")
+	}
+	if flagset.Lookup("h") == nil {
+		flagset.BoolVar(&helpRequested, "h", false, "Display help and exit")
+	}
+	err := flagset.Parse(true, args)
+	if err != nil {
+		return nil, nil, err
+	}
+	if helpRequested {
+		command = m.Commands["help"]
+		args = []string{name}
+	} else {
+		args = flagset.Args()
+	}
+	return command, args, nil
+}
+
 func (m *Manager) finisher() exiter {
+/*	if writer, ok := m.stdout.(*io.Writer); ok {
+		writer.close()
+	}
+	for _, ctx := range m.contexts {
+		if writer, ok := ctx.Stdout.(*io.Writer); ok {
+			writer.close()
+		}
+	}*/
 	if m.e == nil {
 		m.e = osExiter{}
 	}
@@ -127,6 +248,23 @@ type Command interface {
 type FlaggedCommand interface {
 	Command
 	Flags() *gnuflag.FlagSet
+}
+
+type DeprecatedCommand struct {
+	Command
+	oldName string
+}
+
+func (c *DeprecatedCommand) Run(context *Context) error {
+	fmt.Fprintf(context.Stderr, "WARNING: %q has been deprecated, please use %q instead.\n\n", c.oldName, c.Command.Info().Name)
+	return c.Command.Run(context)
+}
+
+func (c *DeprecatedCommand) Flags() *gnuflag.FlagSet {
+	if cmd, ok := c.Command.(FlaggedCommand); ok {
+		return cmd.Flags()
+	}
+	return gnuflag.NewFlagSet("", gnuflag.ContinueOnError)
 }
 
 type Context struct {
@@ -144,27 +282,44 @@ type Info struct {
 	Desc    string
 }
 
+// Implementing the Commandable interface allows extending
+// the megamd command line interface
+type Commandable interface {
+	Commands() []Command
+}
+
+// Implementing the AdminCommandable interface allows extending
+// the megamd admin command line interface
+type AdminCommandable interface {
+	AdminCommands() []Command
+}
+
 type help struct {
 	manager *Manager
 }
 
 func (c *help) Info() *Info {
-	return &Info{
-		Name:  "help",
-		Usage: "command [args]",
-	}
+	return &Info{Name: "help", Usage: "command [args]"}
 }
 
 func (c *help) Run(context *Context) error {
+	const deprecatedMsg = "WARNING: %q is deprecated. Showing help for %q instead.\n\n"
 	output := fmt.Sprintf("%s version %s.\n\n", c.manager.name, c.manager.version)
 	if c.manager.wrong {
 		output += fmt.Sprint("ERROR: wrong number of arguments.\n\n")
 	}
 	if len(context.Args) > 0 {
 		if cmd, ok := c.manager.Commands[context.Args[0]]; ok {
+			if deprecated, ok := cmd.(*DeprecatedCommand); ok {
+				fmt.Fprintf(context.Stderr, deprecatedMsg, deprecated.oldName, cmd.Info().Name)
+			}
 			info := cmd.Info()
 			output += fmt.Sprintf("Usage: %s %s\n", c.manager.name, info.Usage)
 			output += fmt.Sprintf("\n%s\n", info.Desc)
+			flags := c.parseFlags(cmd)
+			if flags != "" {
+				output += fmt.Sprintf("\n%s", flags)
+			}
 			if info.MinArgs > 0 {
 				output += fmt.Sprintf("\nMinimum # of arguments: %d", info.MinArgs)
 			}
@@ -180,12 +335,20 @@ func (c *help) Run(context *Context) error {
 	} else {
 		output += fmt.Sprintf("Usage: %s %s\n\nAvailable commands:\n", c.manager.name, c.Info().Usage)
 		var commands []string
-		for k := range c.manager.Commands {
-			commands = append(commands, k)
+		for name, cmd := range c.manager.Commands {
+			if _, ok := cmd.(*DeprecatedCommand); !ok {
+				commands = append(commands, name)
+			}
 		}
 		sort.Strings(commands)
 		for _, command := range commands {
-			output += fmt.Sprintf("  %s\n", command)
+			description := c.manager.Commands[command].Info().Desc
+			description = strings.Split(description, "\n")[0]
+			description = strings.Split(description, ".")[0]
+			if len(description) > 2 {
+				description = strings.ToUpper(description[:1]) + description[1:]
+			}
+			output += fmt.Sprintf("  %-20s %s\n", command, description)
 		}
 		output += fmt.Sprintf("\nUse %s help <commandname> to get more information about a command.\n", c.manager.name)
 		if len(c.manager.topics) > 0 {
@@ -198,6 +361,20 @@ func (c *help) Run(context *Context) error {
 	}
 	io.WriteString(context.Stdout, output)
 	return nil
+}
+
+func (c *help) parseFlags(command Command) string {
+	var output string
+	if cmd, ok := command.(FlaggedCommand); ok {
+		var buf bytes.Buffer
+		flagset := cmd.Flags()
+		flagset.SetOutput(&buf)
+		flagset.PrintDefaults()
+		if buf.String() != "" {
+			output = fmt.Sprintf("Flags:\n\n%s", buf.String())
+		}
+	}
+	return strings.Replace(output, "\n", "\n  ", -1)
 }
 
 type version struct {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -2,11 +2,604 @@ package cmd
 
 import (
 	"bytes"
-	"errors"
+	"fmt"
 	"io"
 	"os"
+	"regexp"
+	"strings"
+
+	"github.com/megamsys/libgo/fs"
+	"github.com/megamsys/libgo/fs/fstest"
 	"gopkg.in/check.v1"
+	"launchpad.net/gnuflag"
 )
+
+func (s *S) TestDeprecatedCommand(c *check.C) {
+	var stdout, stderr bytes.Buffer
+	cmd := TestCommand{}
+	manager.RegisterDeprecated(&cmd, "bar")
+	manager.stdout = &stdout
+	manager.stderr = &stderr
+	manager.Run([]string{"bar"})
+	c.Assert(stdout.String(), check.Equals, "Running TestCommand")
+	warnMessage := `WARNING: "bar" has been deprecated, please use "foo" instead.` + "\n\n"
+	c.Assert(stderr.String(), check.Equals, warnMessage)
+	stdout.Reset()
+	stderr.Reset()
+	manager.Run([]string{"foo"})
+	c.Assert(stdout.String(), check.Equals, "Running TestCommand")
+	c.Assert(stderr.String(), check.Equals, "")
+}
+
+func (s *S) TestDeprecatedCommandFlags(c *check.C) {
+	var stdout, stderr bytes.Buffer
+	cmd := CommandWithFlags{}
+	manager.RegisterDeprecated(&cmd, "bar")
+	manager.stdout = &stdout
+	manager.stderr = &stderr
+	manager.Run([]string{"bar", "--age", "10"})
+	warnMessage := `WARNING: "bar" has been deprecated, please use "with-flags" instead.` + "\n\n"
+	c.Assert(stderr.String(), check.Equals, warnMessage)
+	c.Assert(cmd.age, check.Equals, 10)
+}
+
+func (s *S) TestRegister(c *check.C) {
+	manager.Register(&TestCommand{})
+	badCall := func() { manager.Register(&TestCommand{}) }
+	c.Assert(badCall, check.PanicMatches, "command already registered: foo")
+}
+
+func (s *S) TestRegisterDeprecated(c *check.C) {
+	originalCmd := &TestCommand{}
+	manager.RegisterDeprecated(originalCmd, "bar")
+	badCall := func() { manager.Register(originalCmd) }
+	c.Assert(badCall, check.PanicMatches, "command already registered: foo")
+	cmd, ok := manager.Commands["bar"].(*DeprecatedCommand)
+	c.Assert(ok, check.Equals, true)
+	c.Assert(cmd.Command, check.Equals, originalCmd)
+	c.Assert(manager.Commands["foo"], check.Equals, originalCmd)
+}
+
+func (s *S) TestRegisterTopic(c *check.C) {
+	manager := Manager{}
+	manager.RegisterTopic("target", "targetting everything!")
+	c.Assert(manager.topics["target"], check.Equals, "targetting everything!")
+}
+
+func (s *S) TestRegisterTopicDuplicated(c *check.C) {
+	manager := Manager{}
+	manager.RegisterTopic("target", "targetting everything!")
+	defer func() {
+		r := recover()
+		c.Assert(r, check.NotNil)
+	}()
+	manager.RegisterTopic("target", "wat")
+}
+
+func (s *S) TestRegisterTopicMultiple(c *check.C) {
+	manager := Manager{}
+	manager.RegisterTopic("target", "targetted")
+	manager.RegisterTopic("app", "what's an app?")
+	expected := map[string]string{
+		"target": "targetted",
+		"app":    "what's an app?",
+	}
+	c.Assert(manager.topics, check.DeepEquals, expected)
+}
+
+func (s *S) TestCustomLookup(c *check.C) {
+	lookup := func(ctx *Context) error {
+		fmt.Fprintf(ctx.Stdout, "test")
+		return nil
+	}
+	var stdout, stderr bytes.Buffer
+	manager := NewManager("glb", "0.x", "Foo-Megam", &stdout, &stderr, os.Stdin, lookup)
+	manager.Run([]string{"custom"})
+	c.Assert(stdout.String(), check.Equals, "test")
+}
+
+func (s *S) TestManagerRunShouldWriteErrorsOnStderr(c *check.C) {
+	manager.Register(&ErrorCommand{msg: "You are wrong\n"})
+	manager.Run([]string{"error"})
+	c.Assert(manager.stderr.(*bytes.Buffer).String(), check.Equals, "Error: You are wrong\n")
+}
+
+func (s *S) TestManagerRunShouldReturnStatus1WhenCommandFail(c *check.C) {
+	manager.Register(&ErrorCommand{msg: "You are wrong\n"})
+	manager.Run([]string{"error"})
+	c.Assert(manager.e.(*recordingExiter).value(), check.Equals, 1)
+}
+
+func (s *S) TestManagerRunShouldAppendNewLineOnErrorWhenItsNotPresent(c *check.C) {
+	manager.Register(&ErrorCommand{msg: "You are wrong"})
+	manager.Run([]string{"error"})
+	c.Assert(manager.stderr.(*bytes.Buffer).String(), check.Equals, "Error: You are wrong\n")
+}
+
+func (s *S) TestManagerRunShouldNotWriteErrorOnStderrWhenErrAbortIsTriggered(c *check.C) {
+	manager.Register(&ErrorCommand{msg: "abort"})
+	manager.Run([]string{"error"})
+	c.Assert(manager.stderr.(*bytes.Buffer).String(), check.Equals, "")
+	c.Assert(manager.e.(*recordingExiter).value(), check.Equals, 1)
+}
+
+func (s *S) TestManagerRunWithFlags(c *check.C) {
+	cmd := &CommandWithFlags{}
+	manager.Register(cmd)
+	manager.Run([]string{"with-flags", "--age", "10"})
+	c.Assert(cmd.fs.Parsed(), check.Equals, true)
+	c.Assert(cmd.age, check.Equals, 10)
+}
+
+func (s *S) TestManagerRunWithFlagsAndArgs(c *check.C) {
+	cmd := &CommandWithFlags{minArgs: 2}
+	manager.Register(cmd)
+	manager.Run([]string{"with-flags", "something", "--age", "20", "otherthing"})
+	c.Assert(cmd.args, check.DeepEquals, []string{"something", "otherthing"})
+}
+
+func (s *S) TestManagerRunWithInvalidValueForFlag(c *check.C) {
+	var exiter recordingExiter
+	old := manager.e
+	manager.e = &exiter
+	defer func() {
+		manager.e = old
+	}()
+	cmd := &CommandWithFlags{}
+	manager.Register(cmd)
+	manager.Run([]string{"with-flags", "--age", "megam"})
+	c.Assert(cmd.fs.Parsed(), check.Equals, true)
+	c.Assert(exiter.value(), check.Equals, 1)
+}
+
+func (s *S) TestRun(c *check.C) {
+	manager.Register(&TestCommand{})
+	manager.Run([]string{"foo"})
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, "Running TestCommand")
+}
+
+func (s *S) TestRunCommandThatDoesNotExist(c *check.C) {
+	manager.Run([]string{"bar"})
+	c.Assert(manager.stderr.(*bytes.Buffer).String(), check.Equals, `Error: command "bar" does not exist`+"\n")
+	c.Assert(manager.e.(*recordingExiter).value(), check.Equals, 1)
+}
+
+func (s *S) TestHelp(c *check.C) {
+	expected := `glb version 1.0.
+
+Usage: glb command [args]
+
+Available commands:
+  help                 ` + `
+  version              Display the current version
+
+Use glb help <commandname> to get more information about a command.
+`
+	manager.RegisterDeprecated(&login{}, "login")
+	context := Context{[]string{}, manager.stdout, manager.stderr, manager.stdin}
+	command := help{manager: manager}
+	err := command.Run(&context)
+	c.Assert(err, check.IsNil)
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
+}
+
+func (s *S) TestHelpWithTopics(c *check.C) {
+	expected := `glb version 1.0.
+
+Usage: glb command [args]
+
+Available commands:
+  help                 ` + `
+  login                Initiates a new megam session for a user
+  version              Display the current version
+
+Use glb help <commandname> to get more information about a command.
+
+Available topics:
+  target
+
+Use glb help <topicname> to get more information about a topic.
+`
+	manager.Register(&login{})
+	manager.RegisterTopic("target", "something")
+	context := Context{[]string{}, manager.stdout, manager.stderr, manager.stdin}
+	command := help{manager: manager}
+	err := command.Run(&context)
+	c.Assert(err, check.IsNil)
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
+}
+
+func (s *S) TestHelpFromTopic(c *check.C) {
+	expected := `glb version 1.0.
+
+Targets
+
+Megam likes to manage targets
+`
+	manager.RegisterTopic("target", "Targets\n\nMegam likes to manage targets\n")
+	context := Context{[]string{"target"}, manager.stdout, manager.stderr, manager.stdin}
+	command := help{manager: manager}
+	err := command.Run(&context)
+	c.Assert(err, check.IsNil)
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
+}
+
+func (s *S) TestHelpCommandShouldBeRegisteredByDefault(c *check.C) {
+	var stdout, stderr bytes.Buffer
+	m := NewManager("megam", "1.0", "", &stdout, &stderr, os.Stdin, nil)
+	_, exists := m.Commands["help"]
+	c.Assert(exists, check.Equals, true)
+}
+
+func (s *S) TestHelpReturnErrorIfTheGivenCommandDoesNotExist(c *check.C) {
+	command := help{manager: manager}
+	context := Context{[]string{"user-create"}, manager.stdout, manager.stderr, manager.stdin}
+	err := command.Run(&context)
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.ErrorMatches, `^command "user-create" does not exist.$`)
+}
+
+func (s *S) TestRunWithoutArgsShouldRunHelp(c *check.C) {
+	expected := `glb version 1.0.
+
+Usage: glb command [args]
+
+Available commands:
+  help                 ` + `
+  version              Display the current version
+
+Use glb help <commandname> to get more information about a command.
+`
+	manager.Run([]string{})
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
+}
+
+func (s *S) TestDashDashHelp(c *check.C) {
+	expected := `glb version 1.0.
+
+Usage: glb command [args]
+
+Available commands:
+  help                 ` + `
+  version              Display the current version
+
+Use glb help <commandname> to get more information about a command.
+`
+	manager.Run([]string{"--help"})
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
+}
+
+func (s *S) TestRunCommandWithDashHelp(c *check.C) {
+	expected := `glb version 1.0.
+
+Usage: glb foo
+
+Foo do anything or nothing.
+
+`
+	manager.Register(&TestCommand{})
+	manager.Run([]string{"foo", "--help"})
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
+}
+
+func (s *S) TestRunCommandWithDashH(c *check.C) {
+	expected := `glb version 1.0.
+
+Usage: glb foo
+
+Foo do anything or nothing.
+
+`
+	manager.Register(&TestCommand{})
+	manager.Run([]string{"foo", "-h"})
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
+}
+
+func (s *S) TestHelpShouldReturnHelpForACmd(c *check.C) {
+	expected := `glb version 1.0.
+
+Usage: glb foo
+
+Foo do anything or nothing.
+
+`
+	manager.Register(&TestCommand{})
+	manager.Run([]string{"help", "foo"})
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
+}
+
+func (s *S) TestDashDashHelpShouldReturnHelpForACmd(c *check.C) {
+	expected := `glb version 1.0.
+
+Usage: glb foo
+
+Foo do anything or nothing.
+
+`
+	manager.Register(&TestCommand{})
+	manager.Run([]string{"--help", "foo"})
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
+}
+
+func (s *S) TestDuplicateHelpFlag(c *check.C) {
+	expected := "help called? true"
+	manager.Register(&HelpCommandWithFlags{})
+	manager.Run([]string{"hflags", "--help"})
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
+}
+
+func (s *S) TestDuplicateHFlag(c *check.C) {
+	expected := "help called? true"
+	manager.Register(&HelpCommandWithFlags{})
+	manager.Run([]string{"hflags", "-h"})
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
+}
+
+func (s *S) TestHelpDeprecatedCmd(c *check.C) {
+	expectedStdout := `glb version 1.0.
+
+Usage: glb foo
+
+Foo do anything or nothing.
+
+`
+	expectedStderr := `WARNING: "bar" is deprecated. Showing help for "foo" instead.` + "\n\n"
+	var stdout, stderr bytes.Buffer
+	manager.stdout = &stdout
+	manager.stderr = &stderr
+	manager.RegisterDeprecated(&TestCommand{}, "bar")
+	manager.Run([]string{"help", "bar"})
+	c.Assert(stdout.String(), check.Equals, expectedStdout)
+	c.Assert(stderr.String(), check.Equals, expectedStderr)
+	stdout.Reset()
+	stderr.Reset()
+	manager.Run([]string{"help", "foo"})
+	c.Assert(stdout.String(), check.Equals, expectedStdout)
+	c.Assert(stderr.String(), check.Equals, "")
+}
+
+func (s *S) TestHelpDeprecatedCmdWritesWarningFirst(c *check.C) {
+	expected := `WARNING: "bar" is deprecated. Showing help for "foo" instead.
+
+glb version 1.0.
+
+Usage: glb foo
+
+Foo do anything or nothing.
+
+`
+	var output bytes.Buffer
+	manager.stdout = &output
+	manager.stderr = &output
+	manager.RegisterDeprecated(&TestCommand{}, "bar")
+	manager.Run([]string{"help", "bar"})
+	c.Assert(output.String(), check.Equals, expected)
+}
+
+func (s *S) TestVersion(c *check.C) {
+	var stdout, stderr bytes.Buffer
+	manager := NewManager("megam", "5.0", "", &stdout, &stderr, os.Stdin, nil)
+	command := version{manager: manager}
+	context := Context{[]string{}, manager.stdout, manager.stderr, manager.stdin}
+	err := command.Run(&context)
+	c.Assert(err, check.IsNil)
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, "megam version 5.0.\n")
+}
+
+func (s *S) TestDashDashVersion(c *check.C) {
+	expected := "glb version 1.0.\n"
+	manager.Run([]string{"--version"})
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
+}
+
+func (s *S) TestVersionInfo(c *check.C) {
+	expected := &Info{
+		Name:    "version",
+		MinArgs: 0,
+		Usage:   "version",
+		Desc:    "display the current version",
+	}
+	c.Assert((&version{}).Info(), check.DeepEquals, expected)
+}
+
+type ArgCmd struct{}
+
+func (c *ArgCmd) Info() *Info {
+	return &Info{
+		Name:    "arg",
+		MinArgs: 1,
+		MaxArgs: 2,
+		Usage:   "arg [args]",
+		Desc:    "some desc",
+	}
+}
+
+func (cmd *ArgCmd) Run(ctx *Context) error {
+	return nil
+}
+
+func (s *S) TestRunWrongArgsNumberShouldRunsHelpAndReturnStatus1(c *check.C) {
+	expected := `glb version 1.0.
+
+ERROR: wrong number of arguments.
+
+Usage: glb arg [args]
+
+some desc
+
+Minimum # of arguments: 1
+Maximum # of arguments: 2
+`
+	manager.Register(&ArgCmd{})
+	manager.Run([]string{"arg"})
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
+	c.Assert(manager.e.(*recordingExiter).value(), check.Equals, 1)
+}
+
+func (s *S) TestRunWithTooManyArguments(c *check.C) {
+	expected := `glb version 1.0.
+
+ERROR: wrong number of arguments.
+
+Usage: glb arg [args]
+
+some desc
+
+Minimum # of arguments: 1
+Maximum # of arguments: 2
+`
+	manager.Register(&ArgCmd{})
+	manager.Run([]string{"arg", "param1", "param2", "param3"})
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
+	c.Assert(manager.e.(*recordingExiter).value(), check.Equals, 1)
+}
+
+func (s *S) TestHelpShouldReturnUsageWithTheCommandName(c *check.C) {
+	expected := `megam version 1.0.
+
+Usage: megam foo
+
+Foo do anything or nothing.
+
+`
+	var stdout, stderr bytes.Buffer
+	manager := NewManager("megam", "1.0", "", &stdout, &stderr, os.Stdin, nil)
+	manager.Register(&TestCommand{})
+	context := Context{[]string{"foo"}, manager.stdout, manager.stderr, manager.stdin}
+	command := help{manager: manager}
+	err := command.Run(&context)
+	c.Assert(err, check.IsNil)
+	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
+}
+
+func (s *S) TestExtractProgramNameWithAbsolutePath(c *check.C) {
+	got := ExtractProgramName("/usr/bin/megam")
+	c.Assert(got, check.Equals, "megam")
+}
+
+func (s *S) TestExtractProgramNameWithRelativePath(c *check.C) {
+	got := ExtractProgramName("./megam")
+	c.Assert(got, check.Equals, "megam")
+}
+
+func (s *S) TestExtractProgramNameWithinThePATH(c *check.C) {
+	got := ExtractProgramName("megam")
+	c.Assert(got, check.Equals, "megam")
+}
+
+func (s *S) TestFinisherReturnsOsExiterIfNotDefined(c *check.C) {
+	m := Manager{}
+	c.Assert(m.finisher(), check.FitsTypeOf, osExiter{})
+}
+
+func (s *S) TestFinisherReturnTheDefinedE(c *check.C) {
+	var exiter recordingExiter
+	m := Manager{e: &exiter}
+	c.Assert(m.finisher(), check.FitsTypeOf, &exiter)
+}
+
+func (s *S) TestVersionIsRegisteredByNewManager(c *check.C) {
+	var stdout, stderr bytes.Buffer
+	manager := NewManager("megam", "1.0", "", &stdout, &stderr, os.Stdin, nil)
+	ver, ok := manager.Commands["version"]
+	c.Assert(ok, check.Equals, true)
+	c.Assert(ver, check.FitsTypeOf, &version{})
+}
+
+func (s *S) TestInvalidCommandFuzzyMatch01(c *check.C) {
+	lookup := func(ctx *Context) error {
+		return os.ErrNotExist
+	}
+	manager := BuildBaseManager("megam", "1.0", "", lookup)
+	var stdout, stderr bytes.Buffer
+	var exiter recordingExiter
+	manager.e = &exiter
+	manager.stdout = &stdout
+	manager.stderr = &stderr
+	manager.Run([]string{"target"})
+	expectedOutput := `.*: "target" is not a megam command. See "megam help".
+
+Did you mean?
+	target-add
+	target-list
+	target-remove
+	target-set
+`
+	expectedOutput = strings.Replace(expectedOutput, "\n", "\\W", -1)
+	expectedOutput = strings.Replace(expectedOutput, "\t", "\\W+", -1)
+	c.Assert(stderr.String(), check.Matches, expectedOutput)
+	c.Assert(manager.e.(*recordingExiter).value(), check.Equals, 1)
+}
+
+func (s *S) TestInvalidCommandFuzzyMatch02(c *check.C) {
+	lookup := func(ctx *Context) error {
+		return os.ErrNotExist
+	}
+	manager := BuildBaseManager("megam", "1.0", "", lookup)
+	var stdout, stderr bytes.Buffer
+	var exiter recordingExiter
+	manager.e = &exiter
+	manager.stdout = &stdout
+	manager.stderr = &stderr
+	manager.Run([]string{"target-lisr"})
+	expectedOutput := `.*: "target-lisr" is not a megam command. See "megam help".
+
+Did you mean?
+	target-list
+`
+	expectedOutput = strings.Replace(expectedOutput, "\n", "\\W", -1)
+	expectedOutput = strings.Replace(expectedOutput, "\t", "\\W+", -1)
+	c.Assert(stderr.String(), check.Matches, expectedOutput)
+	c.Assert(manager.e.(*recordingExiter).value(), check.Equals, 1)
+}
+
+func (s *S) TestInvalidCommandFuzzyMatch03(c *check.C) {
+	lookup := func(ctx *Context) error {
+		return os.ErrNotExist
+	}
+	manager := BuildBaseManager("megam", "1.0", "", lookup)
+	var stdout, stderr bytes.Buffer
+	var exiter recordingExiter
+	manager.e = &exiter
+	manager.stdout = &stdout
+	manager.stderr = &stderr
+	manager.Run([]string{"list"})
+	expectedOutput := `.*: "list" is not a megam command. See "megam help".
+
+Did you mean?
+	target-list
+`
+	expectedOutput = strings.Replace(expectedOutput, "\n", "\\W", -1)
+	expectedOutput = strings.Replace(expectedOutput, "\t", "\\W+", -1)
+	c.Assert(stderr.String(), check.Matches, expectedOutput)
+	c.Assert(manager.e.(*recordingExiter).value(), check.Equals, 1)
+}
+
+func (s *S) TestInvalidCommandFuzzyMatch04(c *check.C) {
+	lookup := func(ctx *Context) error {
+		return os.ErrNotExist
+	}
+	manager := BuildBaseManager("megam", "1.0", "", lookup)
+	var stdout, stderr bytes.Buffer
+	var exiter recordingExiter
+	manager.e = &exiter
+	manager.stdout = &stdout
+	manager.stderr = &stderr
+	manager.Run([]string{"not-command"})
+	expectedOutput := `.*: "not-command" is not a megam command. See "megam help".
+`
+	expectedOutput = strings.Replace(expectedOutput, "\n", "\\W", -1)
+	expectedOutput = strings.Replace(expectedOutput, "\t", "\\W+", -1)
+	c.Assert(stderr.String(), check.Matches, expectedOutput)
+	c.Assert(manager.e.(*recordingExiter).value(), check.Equals, 1)
+}
+
+func (s *S) TestFileSystem(c *check.C) {
+	fsystem = &fstest.RecordingFs{}
+	c.Assert(filesystem(), check.DeepEquals, fsystem)
+	fsystem = nil
+	c.Assert(filesystem(), check.DeepEquals, fs.OsFs{})
+}
 
 type recordingExiter int
 
@@ -42,137 +635,65 @@ func (c *ErrorCommand) Info() *Info {
 }
 
 func (c *ErrorCommand) Run(context *Context) error {
-	return errors.New(c.msg)
-}
-
-func (s *S) TestRegister(c *check.C) {
-	manager.Register(&TestCommand{})
-	badCall := func() { manager.Register(&TestCommand{}) }
-	c.Assert(badCall, check.PanicMatches, "command already registered: foo")
-}
-
-func (s *S) TestManagerRunShouldWriteErrorsOnStderr(c *check.C) {
-	manager.Register(&ErrorCommand{msg: "You are wrong\n"})
-	manager.Run([]string{"error"})
-	c.Assert(manager.stderr.(*bytes.Buffer).String(), check.Equals, "Error: You are wrong\n")
-}
-
-func (s *S) TestRun(c *check.C) {
-	manager.Register(&TestCommand{})
-	manager.Run([]string{"foo"})
-	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, "Running TestCommand")
-}
-
-
-func (s *S) TestHelpCommandShouldBeRegisteredByDefault(c *check.C) {
-	var stdout, stderr bytes.Buffer
-	m := NewManager("gulpd", "0.1", "", &stdout, &stderr, os.Stdin)
-	_, exists := m.Commands["help"]
-	c.Assert(exists, check.Equals, true)
-}
-
-func (s *S) TestHelpReturnErrorIfTheGivenCommandDoesNotExist(c *check.C) {
-	command := help{manager: manager}
-	context := Context{[]string{"someone-create"}, manager.stdout, manager.stderr, manager.stdin}
-	err := command.Run(&context)
-	c.Assert(err, check.NotNil)
-	c.Assert(err, check.ErrorMatches, `^command "someone-create" does not exist.$`)
-}
-
-func (s *S) TestVersion(c *check.C) {
-	var stdout, stderr bytes.Buffer
-	manager := NewManager("gulpd", "0.1", "", &stdout, &stderr, os.Stdin)
-	command := version{manager: manager}
-	context := Context{[]string{}, manager.stdout, manager.stderr, manager.stdin}
-	err := command.Run(&context)
-	c.Assert(err, check.IsNil)
-	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, "gulpd version 0.1.\n")
-}
-
-func (s *S) TestVersionInfo(c *check.C) {
-	expected := &Info{
-		Name:    "version",
-		MinArgs: 0,
-		Usage:   "version",
-		Desc:    "display the current version",
+	if c.msg == "abort" {
+		return ErrAbortCommand
 	}
-	c.Assert((&version{}).Info(), check.DeepEquals, expected)
+	return fmt.Errorf(c.msg)
 }
 
-type ArgCmd struct{}
+type CommandWithFlags struct {
+	fs      *gnuflag.FlagSet
+	age     int
+	minArgs int
+	args    []string
+}
 
-func (c *ArgCmd) Info() *Info {
+func (c *CommandWithFlags) Info() *Info {
 	return &Info{
-		Name:    "arg",
-		MinArgs: 1,
-		MaxArgs: 2,
-		Usage:   "arg [args]",
-		Desc:    "some desc",
+		Name:    "with-flags",
+		Desc:    "with-flags doesn't do anything, really.",
+		Usage:   "with-flags",
+		MinArgs: c.minArgs,
 	}
 }
 
-func (cmd *ArgCmd) Run(ctx *Context) error {
+func (c *CommandWithFlags) Run(context *Context) error {
+	c.args = context.Args
 	return nil
 }
 
-func (s *S) TestRunWrongArgsNumberShouldRunsHelpAndReturnStatus1(c *check.C) {
-	expected := `gulpd version 0.1.
-
-ERROR: wrong number of arguments.
-
-Usage: gulpd arg [args]
-
-some desc
-
-Minimum # of arguments: 1
-Maximum # of arguments: 2
-`
-	manager.Register(&ArgCmd{})
-	manager.Run([]string{"arg"})
-	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
-	c.Assert(manager.e.(*recordingExiter).value(), check.Equals, 1)
+func (c *CommandWithFlags) Flags() *gnuflag.FlagSet {
+	if c.fs == nil {
+		c.fs = gnuflag.NewFlagSet("with-flags", gnuflag.ContinueOnError)
+		c.fs.IntVar(&c.age, "age", 0, "your age")
+		c.fs.IntVar(&c.age, "a", 0, "your age")
+	}
+	return c.fs
 }
 
-func (s *S) TestHelpShouldReturnUsageWithTheCommandName(c *check.C) {
-	expected := `gulpd version 0.1.
-
-Usage: gulpd foo
-
-Foo do anything or nothing.
-
-`
-	var stdout, stderr bytes.Buffer
-	manager := NewManager("gulpd", "0.1", "", &stdout, &stderr, os.Stdin)
-	manager.Register(&TestCommand{})
-	context := Context{[]string{"foo"}, manager.stdout, manager.stderr, manager.stdin}
-	command := help{manager: manager}
-	err := command.Run(&context)
-	c.Assert(err, check.IsNil)
-	c.Assert(manager.stdout.(*bytes.Buffer).String(), check.Equals, expected)
+type HelpCommandWithFlags struct {
+	fs *gnuflag.FlagSet
+	h  bool
 }
 
-func (s *S) TestExtractProgramNameWithAbsolutePath(c *check.C) {
-	got := ExtractProgramName("/home/ram/bin/gulpd")
-	c.Assert(got, check.Equals, "gulpd")
+func (c *HelpCommandWithFlags) Info() *Info {
+	return &Info{
+		Name:  "hflags",
+		Desc:  "hflags doesn't do anything, really.",
+		Usage: "hflags",
+	}
 }
 
-func (s *S) TestExtractProgramNameWithRelativePath(c *check.C) {
-	got := ExtractProgramName("./gulpd")
-	c.Assert(got, check.Equals, "gulpd")
+func (c *HelpCommandWithFlags) Run(context *Context) error {
+	fmt.Fprintf(context.Stdout, "help called? %v", c.h)
+	return nil
 }
 
-func (s *S) TestExtractProgramNameWithinThePATH(c *check.C) {
-	got := ExtractProgramName("gulpd")
-	c.Assert(got, check.Equals, "gulpd")
-}
-
-func (s *S) TestFinisherReturnsOsExiterIfNotDefined(c *check.C) {
-	m := Manager{}
-	c.Assert(m.finisher(), check.FitsTypeOf, osExiter{})
-}
-
-func (s *S) TestFinisherReturnTheDefinedE(c *check.C) {
-	var exiter recordingExiter
-	m := Manager{e: &exiter}
-	c.Assert(m.finisher(), check.FitsTypeOf, &exiter)
+func (c *HelpCommandWithFlags) Flags() *gnuflag.FlagSet {
+	if c.fs == nil {
+		c.fs = gnuflag.NewFlagSet("with-flags", gnuflag.ContinueOnError)
+		c.fs.BoolVar(&c.h, "help", false, "help?")
+		c.fs.BoolVar(&c.h, "h", false, "help?")
+	}
+	return c.fs
 }

--- a/cmd/suite_test.go
+++ b/cmd/suite_test.go
@@ -2,45 +2,31 @@ package cmd
 
 import (
 	"bytes"
-	"gopkg.in/check.v1"
 	"os"
-	"os/exec"
 	"testing"
+
+	"gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) { check.TestingT(t) }
 
 type S struct {
-	stdin   *os.File
-	recover []string
+	stdin        *os.File
+	recover      []string
+	recoverToken []string
 }
 
 var _ = check.Suite(&S{})
 var manager *Manager
 
-func (s *S) SetUpSuite(c *check.C) {
-	targetFile := os.Getenv("HOME") + "/.megam"
-	_, err := os.Stat(targetFile)
-	if err == nil {
-		old := targetFile + ".old"
-		s.recover = []string{"mv", old, targetFile}
-		exec.Command("mv", targetFile, old).Run()
-	} else {
-		s.recover = []string{"rm", targetFile}
-	}
-	f, err := os.Create(targetFile)
-	c.Assert(err, check.IsNil)
-	f.Write([]byte("http://localhost"))
-	f.Close()
-}
-
-func (s *S) TearDownSuite(c *check.C) {
-	exec.Command(s.recover[0], s.recover[1:]...).Run()
-}
-
 func (s *S) SetUpTest(c *check.C) {
 	var stdout, stderr bytes.Buffer
-	manager = NewManager("gulpd", "0.1", "", &stdout, &stderr, os.Stdin)
+	manager = NewManager("glb", "1.0", "", &stdout, &stderr, os.Stdin, nil)
 	var exiter recordingExiter
 	manager.e = &exiter
+	os.Setenv("MEGAM_HOME", "/home/megam")
+}
+
+func (s *S) TearDownTest(c *check.C) {
+	os.Unsetenv("MEGAM_HOME")
 }

--- a/fs/fstest/info.go
+++ b/fs/fstest/info.go
@@ -1,0 +1,43 @@
+// Copyright 2015 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fstest
+
+import (
+	"os"
+	"time"
+)
+
+type fileInfo struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+	isDir   bool
+	sys     interface{}
+}
+
+func (fi *fileInfo) Name() string {
+	return fi.name
+}
+
+func (fi *fileInfo) Size() int64 {
+	return fi.size
+}
+
+func (fi *fileInfo) Mode() os.FileMode {
+	return fi.mode
+}
+
+func (fi *fileInfo) ModTime() time.Time {
+	return fi.modTime
+}
+
+func (fi *fileInfo) IsDir() bool {
+	return fi.isDir
+}
+
+func (fi *fileInfo) Sys() interface{} {
+	return fi.sys
+}

--- a/fs/fstest/info_test.go
+++ b/fs/fstest/info_test.go
@@ -1,0 +1,31 @@
+// Copyright 2015 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fstest
+
+import (
+	"os"
+	"time"
+
+	"gopkg.in/check.v1"
+)
+
+func (s *S) TestFileInfo(c *check.C) {
+	now := time.Now()
+	sysInfo := &now
+	var fi os.FileInfo = &fileInfo{
+		name:    "/home/application/apprc",
+		size:    104857600,
+		mode:    0644,
+		modTime: now,
+		isDir:   false,
+		sys:     sysInfo,
+	}
+	c.Check(fi.Name(), check.Equals, "/home/application/apprc")
+	c.Check(fi.Size(), check.Equals, int64(104857600))
+	c.Check(fi.Mode(), check.Equals, os.FileMode(0644))
+	c.Check(fi.ModTime(), check.DeepEquals, now)
+	c.Check(fi.IsDir(), check.Equals, false)
+	c.Check(fi.Sys(), check.Equals, sysInfo)
+}

--- a/fs/fstest/testing_fs.go
+++ b/fs/fstest/testing_fs.go
@@ -1,0 +1,328 @@
+// Copyright 2015 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package fstest provides fake implementations of the fs package.
+//
+// These implementations can be used to mock out the file system in tests.
+package fstest
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/megamsys/libgo/fs"
+	"github.com/megamsys/libgo/safe"
+)
+
+// FakeFile represents a fake instance of the File interface.
+//
+// Methods from FakeFile act like methods in os.File, but instead of working in
+// a real file, they work in an internal string.
+//
+// An instance of FakeFile is returned by RecordingFs.Open method.
+type FakeFile struct {
+	content string
+	current int64
+	name    string
+	r       *safe.BytesReader
+	f       *os.File
+	modTime time.Time
+}
+
+func (f *FakeFile) reader() *safe.BytesReader {
+	if f.r == nil {
+		f.r = safe.NewBytesReader([]byte(f.content))
+	}
+	return f.r
+}
+
+func (f *FakeFile) Close() error {
+	atomic.StoreInt64(&f.current, 0)
+	if f.f != nil {
+		f.f.Close()
+		f.f = nil
+	}
+	return nil
+}
+
+func (f *FakeFile) Read(p []byte) (n int, err error) {
+	n, err = f.reader().Read(p)
+	atomic.AddInt64(&f.current, int64(n))
+	return
+}
+
+func (f *FakeFile) ReadAt(p []byte, off int64) (n int, err error) {
+	n, err = f.reader().ReadAt(p, off)
+	atomic.AddInt64(&f.current, off+int64(n))
+	return
+}
+
+func (f *FakeFile) Seek(offset int64, whence int) (int64, error) {
+	ncurrent, err := f.reader().Seek(offset, whence)
+	old := atomic.LoadInt64(&f.current)
+	for !atomic.CompareAndSwapInt64(&f.current, old, ncurrent) {
+		old = atomic.LoadInt64(&f.current)
+	}
+	return ncurrent, err
+}
+
+func (f *FakeFile) Name() string {
+	return f.name
+}
+
+func (f *FakeFile) Fd() uintptr {
+	if f.f == nil {
+		var err error
+		p := path.Join(os.TempDir(), "testing-fs-file.txt")
+		f.f, err = os.Create(p)
+		if err != nil {
+			panic(err)
+		}
+	}
+	return f.f.Fd()
+}
+
+func (f *FakeFile) Stat() (fi os.FileInfo, err error) {
+	return &fileInfo{name: f.Name(), size: int64(len(f.content))}, nil
+}
+
+func (f *FakeFile) Write(p []byte) (n int, err error) {
+	n = len(p)
+	cur := atomic.LoadInt64(&f.current)
+	currentSize := len(f.content)
+	end := int(cur) + n
+	if end > currentSize {
+		end = currentSize
+	}
+	diff := cur - int64(currentSize)
+	if diff > 0 {
+		f.content += strings.Repeat("\x00", int(diff)) + string(p)
+	} else {
+		f.content = f.content[:cur] + string(p) + f.content[end:]
+	}
+	return
+}
+
+func (f *FakeFile) WriteString(s string) (ret int, err error) {
+	return f.Write([]byte(s))
+}
+
+func (f *FakeFile) Truncate(size int64) error {
+	f.content = f.content[:size]
+	return nil
+}
+
+// RecordingFs implements the Fs interface providing a "recording" file system.
+//
+// A recording file system is a file system that does not execute any action,
+// just record them.
+//
+// All methods from RecordingFs never return errors.
+type RecordingFs struct {
+	actions      []string
+	actionsMutex sync.Mutex
+
+	files      map[string]*FakeFile
+	filesMutex sync.Mutex
+
+	// FileContent is used to provide content for files opened using
+	// RecordingFs.
+	FileContent string
+}
+
+// HasAction checks if a given action was executed in the filesystem.
+//
+// For example, when you call the Open method with the "/tmp/file.txt"
+// argument, RecordingFs will store locally the action "open /tmp/file.txt" and
+// you can check it calling HasAction:
+//
+//     rfs.Open("/tmp/file.txt")
+//     rfs.HasAction("open /tmp/file.txt") // true
+func (r *RecordingFs) HasAction(action string) bool {
+	r.actionsMutex.Lock()
+	defer r.actionsMutex.Unlock()
+	for _, a := range r.actions {
+		if action == a {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *RecordingFs) open(name string, read bool) (fs.File, error) {
+	r.filesMutex.Lock()
+	defer r.filesMutex.Unlock()
+	if r.files == nil {
+		r.files = make(map[string]*FakeFile)
+		if r.FileContent == "" && read {
+			return nil, syscall.ENOENT
+		}
+	} else if f, ok := r.files[name]; ok {
+		f.r = nil
+		return f, nil
+	} else if r.FileContent == "" && read {
+		return nil, syscall.ENOENT
+	}
+	fil := &FakeFile{content: r.FileContent, name: name}
+	r.files[name] = fil
+	return fil, nil
+}
+
+// Create records the action "create <name>" and returns an instance of
+// FakeFile and nil error.
+func (r *RecordingFs) Create(name string) (fs.File, error) {
+	r.actionsMutex.Lock()
+	r.actions = append(r.actions, "create "+name)
+	r.actionsMutex.Unlock()
+	return r.open(name, false)
+}
+
+// Mkdir records the action "mkdir <name> with mode <perm>" and returns nil.
+func (r *RecordingFs) Mkdir(name string, perm os.FileMode) error {
+	r.actionsMutex.Lock()
+	defer r.actionsMutex.Unlock()
+	r.actions = append(r.actions, fmt.Sprintf("mkdir %s with mode %#o", name, perm))
+	return nil
+}
+
+// MkdirAll records the action "mkdirall <path> with mode <perm>" and returns
+// nil.
+func (r *RecordingFs) MkdirAll(path string, perm os.FileMode) error {
+	r.actionsMutex.Lock()
+	defer r.actionsMutex.Unlock()
+	r.actions = append(r.actions, fmt.Sprintf("mkdirall %s with mode %#o", path, perm))
+	return nil
+}
+
+// Open records the action "open <name>" and returns an instance of FakeFile
+// and nil error.
+func (r *RecordingFs) Open(name string) (fs.File, error) {
+	r.actionsMutex.Lock()
+	r.actions = append(r.actions, "open "+name)
+	r.actionsMutex.Unlock()
+	return r.open(name, true)
+}
+
+// OpenFile records the action "openfile <name> with mode <perm>" and returns
+// an instance of FakeFile and nil error.
+func (r *RecordingFs) OpenFile(name string, flag int, perm os.FileMode) (fs.File, error) {
+	r.actionsMutex.Lock()
+	r.actions = append(r.actions, fmt.Sprintf("openfile %s with mode %#o", name, perm))
+	r.actionsMutex.Unlock()
+	if flag&os.O_EXCL == os.O_EXCL && flag&os.O_CREATE == os.O_CREATE {
+		return nil, syscall.EALREADY
+	}
+	read := flag&syscall.O_CREAT != syscall.O_CREAT &&
+		flag&syscall.O_APPEND != syscall.O_APPEND &&
+		flag&syscall.O_TRUNC != syscall.O_TRUNC &&
+		flag&syscall.O_WRONLY != syscall.O_WRONLY
+	f, err := r.open(name, read)
+	if flag&syscall.O_TRUNC == syscall.O_TRUNC {
+		f.Truncate(0)
+	}
+	if flag&syscall.O_APPEND == syscall.O_APPEND {
+		f.Seek(0, 2)
+	}
+	return f, err
+}
+
+func (r *RecordingFs) deleteFile(name string) {
+	r.filesMutex.Lock()
+	defer r.filesMutex.Unlock()
+	if r.files != nil {
+		delete(r.files, name)
+	}
+}
+
+// Remove records the action "remove <name>" and returns nil.
+func (r *RecordingFs) Remove(name string) error {
+	r.actionsMutex.Lock()
+	r.actions = append(r.actions, "remove "+name)
+	r.actionsMutex.Unlock()
+	r.deleteFile(name)
+	return nil
+}
+
+// RemoveAll records the action "removeall <path>" and returns nil.
+func (r *RecordingFs) RemoveAll(path string) error {
+	r.actionsMutex.Lock()
+	r.actions = append(r.actions, "removeall "+path)
+	r.actionsMutex.Unlock()
+	r.deleteFile(path)
+	return nil
+}
+
+func (r *RecordingFs) Rename(oldname, newname string) error {
+	r.actionsMutex.Lock()
+	r.actions = append(r.actions, "rename "+oldname+" "+newname)
+	r.actionsMutex.Unlock()
+	r.filesMutex.Lock()
+	defer r.filesMutex.Unlock()
+	if r.files == nil {
+		r.files = make(map[string]*FakeFile)
+	}
+	r.files[newname] = r.files[oldname]
+	delete(r.files, oldname)
+	return nil
+}
+
+func (r *RecordingFs) Stat(name string) (os.FileInfo, error) {
+	r.actionsMutex.Lock()
+	defer r.actionsMutex.Unlock()
+	r.actions = append(r.actions, "stat "+name)
+	file, ok := r.files[name]
+	if !ok && r.FileContent == "" {
+		return nil, syscall.ENOENT
+	}
+	info := fileInfo{name: name, size: int64(len(r.FileContent))}
+	if file != nil {
+		info.size = int64(len(file.content))
+	}
+	return &info, nil
+}
+
+// FileNotFoundFs is like RecordingFs, except that it returns ENOENT on Open,
+// OpenFile and Remove.
+type FileNotFoundFs struct {
+	RecordingFs
+}
+
+func (r *FileNotFoundFs) Open(name string) (fs.File, error) {
+	r.RecordingFs.Open(name)
+	err := os.PathError{Err: syscall.ENOENT, Path: name}
+	return nil, &err
+}
+
+func (r *FileNotFoundFs) Remove(name string) error {
+	r.RecordingFs.Remove(name)
+	return &os.PathError{Err: syscall.ENOENT, Path: name}
+}
+
+func (r *FileNotFoundFs) RemoveAll(path string) error {
+	r.RecordingFs.RemoveAll(path)
+	return &os.PathError{Err: syscall.ENOENT, Path: path}
+}
+
+func (r *FileNotFoundFs) OpenFile(name string, flag int, perm os.FileMode) (fs.File, error) {
+	r.RecordingFs.OpenFile(name, flag, perm)
+	return r.Open(name)
+}
+
+// FailureFs is like RecordingFs, except the it returns an arbitrary error on
+// operations.
+type FailureFs struct {
+	RecordingFs
+	Err error
+}
+
+func (r *FailureFs) Open(name string) (fs.File, error) {
+	r.RecordingFs.Open(name)
+	return nil, r.Err
+}

--- a/fs/fstest/testing_fs_test.go
+++ b/fs/fstest/testing_fs_test.go
@@ -1,0 +1,433 @@
+// Copyright 2015 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fstest
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/megamsys/libgo/fs"
+	"gopkg.in/check.v1"
+)
+
+type S struct{}
+
+var _ = check.Suite(&S{})
+
+func Test(t *testing.T) {
+	check.TestingT(t)
+}
+
+func (s *S) TestFakeFilePointerShouldImplementFileInterface(c *check.C) {
+	var _ fs.File = &FakeFile{}
+}
+
+func (s *S) TestFakeFileClose(c *check.C) {
+	f := &FakeFile{content: "doesn't matter"}
+	f.current = 500
+	err := f.Close()
+	c.Assert(err, check.IsNil)
+	c.Assert(f.current, check.Equals, int64(0))
+}
+
+func (s *S) TestFakeFileCloseInternalFilePointer(c *check.C) {
+	f := &FakeFile{}
+	f.Fd()
+	c.Assert(f.f, check.NotNil)
+	f.Close()
+	c.Assert(f.f, check.IsNil)
+}
+
+func (s *S) TestFakeFileRead(c *check.C) {
+	content := "all I am"
+	f := &FakeFile{content: content}
+	buf := make([]byte, 20)
+	n, err := f.Read(buf)
+	c.Assert(err, check.IsNil)
+	c.Assert(n, check.Equals, len(content))
+	c.Assert(string(buf[:n]), check.Equals, content)
+	c.Assert(f.current, check.Equals, int64(len(content)))
+}
+
+func (s *S) TestFakeFileReadAt(c *check.C) {
+	content := "invisible cage"
+	f := &FakeFile{content: content}
+	buf := make([]byte, 4)
+	n, err := f.ReadAt(buf, int64(len(content)-len(buf)))
+	c.Assert(err, check.IsNil)
+	c.Assert(n, check.Equals, 4)
+	c.Assert(string(buf), check.Equals, "cage")
+	c.Assert(f.current, check.Equals, int64(len(content)))
+}
+
+func (s *S) TestFakeFileSeek(c *check.C) {
+	content := "fragile equality"
+	f := &FakeFile{content: content}
+	n, err := f.Seek(8, 0)
+	c.Assert(err, check.IsNil)
+	c.Assert(n, check.Equals, int64(8))
+	buf := make([]byte, 5)
+	read, err := f.Read(buf)
+	c.Assert(err, check.IsNil)
+	c.Assert(read, check.Equals, 5)
+	c.Assert(string(buf), check.Equals, "equal")
+}
+
+func (s *S) TestFakeFileFd(c *check.C) {
+	f := &FakeFile{}
+	defer f.Close()
+	fd := f.Fd()
+	c.Assert(fd, check.Equals, f.f.Fd())
+}
+
+func (s *S) TestFakeFileName(c *check.C) {
+	var f FakeFile
+	f.name = "/home/user/.bash_profile"
+	defer f.Close()
+	c.Assert(f.Name(), check.Equals, f.name)
+}
+
+func (s *S) TestFakeFileStat(c *check.C) {
+	expected := &fileInfo{name: "something", size: 14}
+	f := &FakeFile{name: "something", content: "doesn't matter"}
+	fi, err := f.Stat()
+	c.Assert(err, check.IsNil)
+	c.Assert(fi, check.DeepEquals, expected)
+}
+
+func (s *S) TestFakeFileWrite(c *check.C) {
+	content := "Guardian"
+	f := &FakeFile{content: content}
+	n, err := f.Write([]byte("break"))
+	c.Assert(err, check.IsNil)
+	c.Assert(n, check.Equals, len("break"))
+	c.Assert(f.content, check.Equals, "breakian")
+}
+
+func (s *S) TestFakeFileWriteFromPosition(c *check.C) {
+	content := "Guardian"
+	f := &FakeFile{content: content}
+	n, err := f.Seek(5, 0)
+	c.Assert(err, check.IsNil)
+	c.Assert(n, check.Equals, int64(5))
+	written, err := f.Write([]byte("break"))
+	c.Assert(err, check.IsNil)
+	c.Assert(written, check.Equals, len("break"))
+	c.Assert(f.content, check.Equals, "Guardbreak")
+}
+
+func (s *S) TestFakeFileWriteString(c *check.C) {
+	content := "Guardian"
+	f := &FakeFile{content: content}
+	ret, err := f.WriteString("break")
+	c.Assert(err, check.IsNil)
+	c.Assert(ret, check.Equals, len("break"))
+	c.Assert(f.content, check.Equals, "breakian")
+	f.current = int64(ret)
+	ret, err = f.WriteString("break")
+	c.Assert(err, check.IsNil)
+	c.Assert(ret, check.Equals, len("break"))
+	c.Assert(f.content, check.Equals, "breakbreak")
+}
+
+func (s *S) TestFakeFileTruncateDoesNotChangeCurrent(c *check.C) {
+	content := "Guardian"
+	f := &FakeFile{content: content}
+	f.current = 4
+	cur := f.current
+	err := f.Truncate(0)
+	c.Assert(err, check.IsNil)
+	c.Assert(f.current, check.Equals, cur)
+}
+
+func (s *S) TestFakeFileTruncateStripsContentWithN(c *check.C) {
+	content := "Guardian"
+	f := &FakeFile{content: content}
+	err := f.Truncate(4)
+	c.Assert(err, check.IsNil)
+	c.Assert(f.content, check.Equals, "Guar")
+}
+
+func (s *S) TestFakeFileTruncateWithoutSeek(c *check.C) {
+	content := "Guardian"
+	f := &FakeFile{content: content}
+	f.current = int64(len(content))
+	err := f.Truncate(0)
+	c.Assert(err, check.IsNil)
+	tow := []byte("otherthing")
+	n, err := f.Write(tow)
+	c.Assert(err, check.IsNil)
+	c.Assert(n, check.Equals, len(tow))
+	nulls := strings.Repeat("\x00", int(f.current))
+	c.Assert(f.content, check.Equals, nulls+string(tow))
+}
+
+func (s *S) TestRecordingFsPointerShouldImplementFsInterface(c *check.C) {
+	var _ fs.Fs = &RecordingFs{}
+}
+
+func (s *S) TestRecordingFsHasAction(c *check.C) {
+	fs := RecordingFs{actions: []string{"torn", "shade of my soul"}}
+	c.Assert(fs.HasAction("torn"), check.Equals, true)
+	c.Assert(fs.HasAction("shade of my soul"), check.Equals, true)
+	c.Assert(fs.HasAction("meaningles world"), check.Equals, false)
+}
+
+func (s *S) TestRecordingFsCreate(c *check.C) {
+	fs := RecordingFs{}
+	f, err := fs.Create("/my/file.txt")
+	c.Assert(err, check.IsNil)
+	c.Assert(fs.HasAction("create /my/file.txt"), check.Equals, true)
+	c.Assert(f, check.FitsTypeOf, &FakeFile{})
+}
+
+func (s *S) TestRecordingFsMkdir(c *check.C) {
+	fs := RecordingFs{}
+	err := fs.Mkdir("/my/dir", 0777)
+	c.Assert(err, check.IsNil)
+	c.Assert(fs.HasAction("mkdir /my/dir with mode 0777"), check.Equals, true)
+}
+
+func (s *S) TestRecordingFsMkdirAll(c *check.C) {
+	fs := RecordingFs{}
+	err := fs.MkdirAll("/my/dir/with/subdir", 0777)
+	c.Assert(err, check.IsNil)
+	c.Assert(fs.HasAction("mkdirall /my/dir/with/subdir with mode 0777"), check.Equals, true)
+}
+
+func (s *S) TestRecordingFsOpen(c *check.C) {
+	fs := RecordingFs{FileContent: "the content"}
+	f, err := fs.Open("/my/file")
+	c.Assert(err, check.IsNil)
+	c.Assert(fs.HasAction("open /my/file"), check.Equals, true)
+	c.Assert(f, check.FitsTypeOf, &FakeFile{})
+	c.Assert(f.(*FakeFile).content, check.Equals, fs.FileContent)
+}
+
+func (s *S) TestRecordingFsOpenFile(c *check.C) {
+	fs := RecordingFs{FileContent: "the content"}
+	f, err := fs.OpenFile("/my/file", 0, 0600)
+	c.Assert(err, check.IsNil)
+	c.Assert(fs.HasAction("openfile /my/file with mode 0600"), check.Equals, true)
+	c.Assert(f, check.FitsTypeOf, &FakeFile{})
+	c.Assert(f.(*FakeFile).content, check.Equals, fs.FileContent)
+}
+
+func (s *S) TestRecordingFsOpenFileTruncate(c *check.C) {
+	fs := RecordingFs{FileContent: "the content"}
+	f, err := fs.OpenFile("/my/file", syscall.O_TRUNC, 0600)
+	c.Assert(err, check.IsNil)
+	c.Assert(fs.HasAction("openfile /my/file with mode 0600"), check.Equals, true)
+	c.Assert(f, check.FitsTypeOf, &FakeFile{})
+	c.Assert(f.(*FakeFile).content, check.Equals, "")
+}
+
+func (s *S) TestRecordingFsOpenFileAppend(c *check.C) {
+	fs := RecordingFs{}
+	f, err := fs.OpenFile("/my/file", syscall.O_APPEND|syscall.O_WRONLY, 0644)
+	c.Assert(err, check.IsNil)
+	f.Write([]byte("Hi there!\n"))
+	f.Close()
+	f, err = fs.OpenFile("/my/file", syscall.O_APPEND|syscall.O_WRONLY, 0644)
+	c.Assert(err, check.IsNil)
+	f.Write([]byte("Hi there!\n"))
+	f.Close()
+	f, err = fs.Open("/my/file")
+	c.Assert(err, check.IsNil)
+	defer f.Close()
+	b, err := ioutil.ReadAll(f)
+	c.Assert(err, check.IsNil)
+	c.Assert(string(b), check.Equals, "Hi there!\nHi there!\n")
+}
+
+func (s *S) TestRecordingFsOpenFileCreateAndExclusive(c *check.C) {
+	fs := RecordingFs{}
+	f, err := fs.OpenFile("/my/file", os.O_EXCL|os.O_CREATE, 0600)
+	c.Assert(err, check.Equals, syscall.EALREADY)
+	c.Assert(f, check.IsNil)
+}
+
+func (s *S) TestRecordingFsOpenFileReadAndWriteENOENT(c *check.C) {
+	fs := RecordingFs{}
+	f, err := fs.OpenFile("/my/file", syscall.O_RDWR, 0600)
+	c.Assert(f, check.IsNil)
+	c.Assert(err, check.Equals, syscall.ENOENT)
+}
+
+func (s *S) TestRecordingFsKeepFileInstances(c *check.C) {
+	fs := RecordingFs{FileContent: "the content"}
+	f, err := fs.Create("/my/file")
+	c.Assert(err, check.IsNil)
+	f.Write([]byte("hi"))
+	f, err = fs.Open("/my/file")
+	c.Assert(err, check.IsNil)
+	buf := make([]byte, 2)
+	n, err := f.Read(buf)
+	c.Assert(err, check.IsNil)
+	c.Assert(n, check.Equals, 2)
+	c.Assert(string(buf), check.Equals, "hi")
+	// Opening again should read seek to position 0 in the reader
+	f, _ = fs.Open("/my/file")
+	n, err = f.Read(buf)
+	c.Assert(err, check.IsNil)
+	c.Assert(n, check.Equals, 2)
+	c.Assert(string(buf), check.Equals, "hi")
+}
+
+func (s *S) TestRecordingFsShouldKeepWrittenContent(c *check.C) {
+	fs := RecordingFs{FileContent: "the content"}
+	f, _ := fs.Open("/my/file")
+	buf := make([]byte, 16)
+	n, _ := f.Read(buf)
+	f.Close()
+	c.Assert(string(buf[:n]), check.Equals, "the content")
+	f, _ = fs.Create("/my/file")
+	f.Write([]byte("content the"))
+	f.Close()
+	f, _ = fs.Open("/my/file")
+	n, _ = f.Read(buf)
+	c.Assert(string(buf[:n]), check.Equals, "content the")
+}
+
+func (s *S) TestRecordingFsFailToOpenUnknownFilesWithoutContent(c *check.C) {
+	fs := RecordingFs{}
+	f, err := fs.Open("/my/file")
+	c.Assert(f, check.IsNil)
+	c.Assert(err, check.NotNil)
+	c.Assert(os.IsNotExist(err), check.Equals, true)
+}
+
+func (s *S) TestRecordingFsRemove(c *check.C) {
+	fs := RecordingFs{}
+	err := fs.Remove("/my/file")
+	c.Assert(err, check.IsNil)
+	c.Assert(fs.HasAction("remove /my/file"), check.Equals, true)
+}
+
+func (s *S) TestRecordingFsRemoveDeletesState(c *check.C) {
+	fs := RecordingFs{FileContent: "hi"}
+	f, _ := fs.Open("/my/file")
+	f.Write([]byte("ih"))
+	fs.Remove("/my/file")
+	f, _ = fs.Open("/my/file")
+	buf := make([]byte, 2)
+	f.Read(buf)
+	c.Assert(string(buf), check.Equals, "hi")
+}
+
+func (s *S) TestRecordingFsRemoveAll(c *check.C) {
+	fs := RecordingFs{}
+	err := fs.RemoveAll("/my/dir")
+	c.Assert(err, check.IsNil)
+	c.Assert(fs.HasAction("removeall /my/dir"), check.Equals, true)
+}
+
+func (s *S) TestRecordingFsRemoveAllDeletesState(c *check.C) {
+	fs := RecordingFs{FileContent: "hi"}
+	f, _ := fs.Open("/my/file")
+	f.Write([]byte("ih"))
+	fs.RemoveAll("/my/file")
+	f, _ = fs.Open("/my/file")
+	buf := make([]byte, 2)
+	f.Read(buf)
+	c.Assert(string(buf), check.Equals, "hi")
+}
+
+func (s *S) TestRecordingFsRename(c *check.C) {
+	fs := RecordingFs{}
+	f, _ := fs.Create("/my/file")
+	f.Write([]byte("hello, hello!"))
+	f.Close()
+	err := fs.Rename("/my/file", "/your/file")
+	c.Assert(err, check.IsNil)
+	_, err = fs.Open("/my/file")
+	c.Assert(err, check.NotNil)
+	f, err = fs.Open("/your/file")
+	c.Assert(err, check.IsNil)
+	defer f.Close()
+	b, _ := ioutil.ReadAll(f)
+	c.Assert(string(b), check.Equals, "hello, hello!")
+	c.Assert(fs.HasAction("rename /my/file /your/file"), check.Equals, true)
+}
+
+func (s *S) TestRecordingFsCold(c *check.C) {
+	fs := RecordingFs{}
+	err := fs.Rename("/my/file", "/your/file")
+	c.Assert(err, check.IsNil)
+}
+
+func (s *S) TestRecordingFsStat(c *check.C) {
+	info := &fileInfo{name: "/my/file", size: 9}
+	fs := RecordingFs{FileContent: "something"}
+	fi, err := fs.Stat("/my/file")
+	c.Assert(err, check.IsNil)
+	c.Assert(fi, check.DeepEquals, info)
+}
+
+func (s *S) TestRecordingFsStatNotFound(c *check.C) {
+	fs := RecordingFs{}
+	fi, err := fs.Stat("/my/file")
+	c.Assert(os.IsNotExist(err), check.Equals, true)
+	c.Assert(fi, check.IsNil)
+	c.Assert(fs.HasAction("stat /my/file"), check.Equals, true)
+}
+
+func (s *S) TestFileNotFoundFsPointerImplementsFsInterface(c *check.C) {
+	var _ fs.Fs = &FileNotFoundFs{}
+}
+
+func (s *S) TestFileNotFoundFsOpen(c *check.C) {
+	fs := FileNotFoundFs{}
+	f, err := fs.Open("/my/file")
+	c.Assert(f, check.IsNil)
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.FitsTypeOf, &os.PathError{})
+	c.Assert(err.(*os.PathError).Err, check.DeepEquals, syscall.ENOENT)
+	c.Assert(err.(*os.PathError).Path, check.Equals, "/my/file")
+	c.Assert(fs.HasAction("open /my/file"), check.Equals, true)
+}
+
+func (s *S) TestFileNotFoundFsRemove(c *check.C) {
+	fs := FileNotFoundFs{}
+	err := fs.Remove("/my/file")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.FitsTypeOf, &os.PathError{})
+	c.Assert(err.(*os.PathError).Err, check.DeepEquals, syscall.ENOENT)
+	c.Assert(err.(*os.PathError).Path, check.Equals, "/my/file")
+	c.Assert(fs.HasAction("remove /my/file"), check.Equals, true)
+}
+
+func (s *S) TestFileNotFoundFsOpenFile(c *check.C) {
+	fs := FileNotFoundFs{}
+	f, err := fs.OpenFile("/my/file", 0, 0600)
+	c.Assert(f, check.IsNil)
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.FitsTypeOf, &os.PathError{})
+	c.Assert(err.(*os.PathError).Err, check.DeepEquals, syscall.ENOENT)
+	c.Assert(err.(*os.PathError).Path, check.Equals, "/my/file")
+	c.Assert(fs.HasAction("open /my/file"), check.Equals, true)
+}
+
+func (s *S) TestFileNotFoundFsRemoveAll(c *check.C) {
+	fs := FileNotFoundFs{}
+	err := fs.RemoveAll("/my/file")
+	c.Assert(err, check.NotNil)
+	c.Assert(err, check.FitsTypeOf, &os.PathError{})
+	c.Assert(err.(*os.PathError).Err, check.DeepEquals, syscall.ENOENT)
+	c.Assert(err.(*os.PathError).Path, check.Equals, "/my/file")
+	c.Assert(fs.HasAction("removeall /my/file"), check.Equals, true)
+}
+
+func (s *S) TestFailureFsOpen(c *check.C) {
+	origErr := errors.New("something went wrong")
+	fs := FailureFs{Err: origErr}
+	file, gotErr := fs.Open("/wat")
+	c.Assert(file, check.IsNil)
+	c.Assert(gotErr, check.Equals, origErr)
+}

--- a/safe/reader.go
+++ b/safe/reader.go
@@ -1,0 +1,76 @@
+// Copyright 2014 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package safe
+
+import (
+	"bytes"
+	"io"
+	"sync"
+)
+
+// BytesReader is a thread safe version of bytes.Reader.
+type BytesReader struct {
+	reader bytes.Reader
+	mutex  sync.Mutex
+}
+
+func NewBytesReader(b []byte) *BytesReader {
+	reader := bytes.NewReader(b)
+	return &BytesReader{reader: *reader}
+}
+
+func (r *BytesReader) Len() int {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.reader.Len()
+}
+
+func (r *BytesReader) Read(b []byte) (int, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.reader.Read(b)
+}
+
+func (r *BytesReader) ReadAt(b []byte, off int64) (int, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.reader.ReadAt(b, off)
+}
+
+func (r *BytesReader) ReadByte() (byte, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.reader.ReadByte()
+}
+
+func (r *BytesReader) ReadRune() (rune, int, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.reader.ReadRune()
+}
+
+func (r *BytesReader) Seek(offset int64, whence int) (int64, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.reader.Seek(offset, whence)
+}
+
+func (r *BytesReader) UnreadByte() error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.reader.UnreadByte()
+}
+
+func (r *BytesReader) UnreadRune() error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.reader.UnreadRune()
+}
+
+func (r *BytesReader) WriteTo(w io.Writer) (int64, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.reader.WriteTo(w)
+}

--- a/safe/reader_test.go
+++ b/safe/reader_test.go
@@ -1,0 +1,110 @@
+// Copyright 2015 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package safe
+
+import (
+	"bytes"
+
+	"gopkg.in/check.v1"
+)
+
+func (s *S) TestSafeBytesReaderLen(c *check.C) {
+	content := []byte("something")
+	reader := NewBytesReader(content)
+	length := reader.Len()
+	c.Assert(length, check.Equals, len(content))
+}
+
+func (s *S) TestSafeBytesReaderRead(c *check.C) {
+	var buf [4]byte
+	content := []byte("something")
+	reader := NewBytesReader(content)
+	n, err := reader.Read(buf[:])
+	c.Assert(err, check.IsNil)
+	c.Assert(n, check.Equals, 4)
+	c.Assert(string(buf[:]), check.Equals, "some")
+}
+
+func (s *S) TestSafeBytesReaderReadAt(c *check.C) {
+	var buf [4]byte
+	content := []byte("something")
+	reader := NewBytesReader(content)
+	n, err := reader.ReadAt(buf[:], 1)
+	c.Assert(err, check.IsNil)
+	c.Assert(n, check.Equals, 4)
+	c.Assert(string(buf[:]), check.Equals, "omet")
+}
+
+func (s *S) TestSafeBytesReaderReadByte(c *check.C) {
+	content := []byte("something")
+	reader := NewBytesReader(content)
+	b, err := reader.ReadByte()
+	c.Assert(err, check.IsNil)
+	c.Assert(b, check.Equals, content[0])
+	b, err = reader.ReadByte()
+	c.Assert(err, check.IsNil)
+	c.Assert(b, check.Equals, content[1])
+}
+
+func (s *S) TestSafeBytesReaderReadRune(c *check.C) {
+	content := []byte("something")
+	reader := NewBytesReader(content)
+	b, size, err := reader.ReadRune()
+	c.Assert(err, check.IsNil)
+	c.Assert(size, check.Equals, 1)
+	c.Assert(b, check.Equals, 's')
+}
+
+func (s *S) TestSafeBytesReaderSeek(c *check.C) {
+	content := []byte("something")
+	reader := NewBytesReader(content)
+	b, err := reader.ReadByte()
+	c.Assert(err, check.IsNil)
+	c.Assert(b, check.Equals, content[0])
+	off, err := reader.Seek(0, 0)
+	c.Assert(err, check.IsNil)
+	c.Assert(off, check.Equals, int64(0))
+	b, err = reader.ReadByte()
+	c.Assert(err, check.IsNil)
+	c.Assert(b, check.Equals, content[0])
+}
+
+func (s *S) TestSafeBytesReaderUnreadByte(c *check.C) {
+	content := []byte("something")
+	reader := NewBytesReader(content)
+	b, err := reader.ReadByte()
+	c.Assert(err, check.IsNil)
+	c.Assert(b, check.Equals, content[0])
+	err = reader.UnreadByte()
+	c.Assert(err, check.IsNil)
+	b, err = reader.ReadByte()
+	c.Assert(err, check.IsNil)
+	c.Assert(b, check.Equals, content[0])
+}
+
+func (s *S) TestSafeBytesReaderUnreadRune(c *check.C) {
+	content := []byte("something")
+	reader := NewBytesReader(content)
+	b, size, err := reader.ReadRune()
+	c.Assert(err, check.IsNil)
+	c.Assert(size, check.Equals, 1)
+	c.Assert(b, check.Equals, 's')
+	err = reader.UnreadRune()
+	c.Assert(err, check.IsNil)
+	b, size, err = reader.ReadRune()
+	c.Assert(err, check.IsNil)
+	c.Assert(size, check.Equals, 1)
+	c.Assert(b, check.Equals, 's')
+}
+
+func (s *S) TestSafeBytesReaderWriteTo(c *check.C) {
+	var buf bytes.Buffer
+	content := []byte("something")
+	reader := NewBytesReader(content)
+	n, err := reader.WriteTo(&buf)
+	c.Assert(err, check.IsNil)
+	c.Assert(n, check.Equals, int64(len(content)))
+	c.Assert(buf.String(), check.Equals, "something")
+}


### PR DESCRIPTION
- v : `verbose` is where debug is set.
Currently its set by default in the main.go. 

Looking at moving into libgo cmd/manager.go. When it finds a -v flag, set log.SetLevel(Debug)